### PR TITLE
Fulfill view controller containment contract

### DIFF
--- a/GroceryList/GCYTableViewController.m
+++ b/GroceryList/GCYTableViewController.m
@@ -24,7 +24,7 @@
 
 	_childTableViewController = [[UITableViewController alloc] initWithStyle:UITableViewStylePlain];
 	[self addChildViewController:self.childTableViewController];
-
+	[self.childTableViewController didMoveToParentViewController:self];
 	return self;
 }
 


### PR DESCRIPTION
From Apple documentation:
addChildViewController: will call [child willMoveToParentViewController:self] before adding the
  child. However, it will not call didMoveToParentViewController:. It is expected that a container view
  controller subclass will make this call after a transition to the new child has completed or, in the
  case of no transition, immediately after the call to addChildViewController:.
